### PR TITLE
Add empty object in case that body is an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ TestRail.prototype._callAPI = function (method, url, queryVariables, body, callb
       if(err) {
         return callback(err);
       }
+      var responseBody = body === '' ? JSON.stringify({}) : body;
       if(res.statusCode != 200) {
         var errData = body;
         try {
@@ -69,7 +70,7 @@ TestRail.prototype._callAPI = function (method, url, queryVariables, body, callb
         } catch (err) {}
         return callback(errData);
       }
-      return callback(null, JSON.parse(body));
+      return callback(null, JSON.parse(responseBody));
     }).auth(this.user, this.password, true);
   }
   else {
@@ -78,6 +79,7 @@ TestRail.prototype._callAPI = function (method, url, queryVariables, body, callb
         if(err) {
           return reject(err);
         }
+        var responseBody = body === '' ? JSON.stringify({}) : body;
         if(res.statusCode != 200) {
           var errData = body;
           try {
@@ -85,7 +87,7 @@ TestRail.prototype._callAPI = function (method, url, queryVariables, body, callb
           } catch (err) {}
           return reject(errData);
         }
-        return resolve(JSON.parse(body));
+        return resolve(JSON.parse(responseBody));
       }).auth(this.user, this.password, true);
     }.bind(this));
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testrail-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A complete API wrapper for TestRail - with 100% code coverage",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`JSON.parse` results in an error, if its parameter is invalid.

In this case, Testrail's body parameter is just
```javascript
''
```
which is invalid JSON.

For this special case I have added changed it into an empty object.

This case occurred when trying to delete a section, as explained in #5 .
