### PR TITLE
Fixing errors in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare class TestrailApiClient {
 }
 
 declare namespace TestrailApiClient {
-    type CustomFieldType = boolean | string | number | number[] | any[];
+    type CustomFieldType = boolean | string | number | number[] | any[] | undefined;
 
     type PromiseResponse<T> = Promise<{ response: Response, body: T }>
 


### PR DESCRIPTION
When I include the testrail-api in my project I get about 30 errors like the following:

`node_modules/testrail-api/index.d.ts(148,9): error TS2411: Property 'refs' of type 'string | undefined' is not assignable to string index type 'CustomFieldType'.`

Because the index types all return `CustomFieldType`, which doesn't include `undefined` as a possibility. So I've added it here to prevent the errors.

I'm not sure why you don't get the errors, maybe we have different tsconfig settings? These are ours:
```
"outDir": "./dist/", // path to output directory
    "sourceMap": true, // allow sourcemap support
    "noImplicitAny": true, // Raise error on expressions and declarations with an implied 'any' type.
    "strictNullChecks": true, // enable strict null checks as a best practice
    "noImplicitThis": true, // Raise error on 'this' expressions with an implied 'any' type.
    "module": "es6", // specify module code generation
    "moduleResolution": "node", // Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6).
    "jsx": "react", // use typescript to transpile jsx to js
    "target": "es5", // specify ECMAScript target version
    "allowJs": true, // allow a partial TypeScript and JavaScript codebase
    "baseUrl": "./", // enables absolute path imports,
    "forceConsistentCasingInFileNames": true,
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "alwaysStrict": true,
    "paths": {
      // define absolute path mappings
      "*": ["*", "src/*"]
    },
    "allowSyntheticDefaultImports": true,
```
I tried with strictNullChecks and noImplicitAny turned off and then I didn't get the errors, so maybe you don't have those settings turned on, but I'd suggest turning them on 