### PR TITLE
fix getSections call missing required suite_id

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,8 +383,8 @@ TestRail.prototype.getSection = function (id, callback) {
   return this.apiGet('get_section/' + id, callback);
 };
 
-TestRail.prototype.getSections = function (project_id, filters, callback) {
-  var uri = 'get_sections/' + project_id;
+TestRail.prototype.getSections = function (project_id, suite_id, filters, callback) {
+  var uri = 'get_sections/' + project_id  + '&suite_id=' + suite_id;
 
   if(typeof filters == 'function') {
     callback = filters;


### PR DESCRIPTION
testrail api v2 getSections call requires project_id and suite_id,
call from here only supplied project_id and suite_id is missing.
This commit fixes this issue.