### PR TITLE
Updated INewTestRun type to allow optional fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -317,11 +317,11 @@ declare namespace TestrailApiClient {
     }
 
     interface INewTestRun {
-        suite_id: number;
-        name: string;
-        description: string;
-        milestone_id: number;
-        assignedto_id: number;
+        suite_id?: number;
+        name?: string;
+        description?: string;
+        milestone_id?: number;
+        assignedto_id?: number;
         include_all: boolean;
         case_ids: number[];
     }


### PR DESCRIPTION
Not sure if this was generated, but we don't need to provide all of these fields for a valid api call.