### PR TITLE
Add optional project_id on get_users end point

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare class TestrailApiClient {
 
     getUser(id: number, callback?: t.Callback<t.ITestrailUser>): t.PromiseResponse<t.ITestrailUser>;
     getUserByEmail(email: string, callback?: t.Callback<t.ITestrailUser>): t.PromiseResponse<t.ITestrailUser>;
-    getUsers(callback?: t.Callback<t.ITestrailUser[]>): t.PromiseResponse<t.ITestrailUser[]>;
+    getUsers(project_id?: number, callback?: t.Callback<t.ITestrailUser[]>): t.PromiseResponse<t.ITestrailUser[]>;
 }
 
 declare namespace TestrailApiClient {

--- a/index.js
+++ b/index.js
@@ -470,8 +470,19 @@ TestRail.prototype.getUserByEmail = function (email, callback) {
   return this.apiGet('get_user_by_email', {email: email}, callback);
 };
 
-TestRail.prototype.getUsers = function (callback) {
-  return this.apiGet('get_users', callback);
+TestRail.prototype.getUsers = function (project_id, callback) {
+  var url = 'get_users';
+
+  if (typeof project_id === 'function') {
+    callback = project_id;
+    project_id = undefined;
+  }
+
+  if (project_id !== undefined) {
+    url += '/' + project_id;
+  }
+
+  return this.apiGet(url, callback);
 };
 
 // ----------

--- a/test/users.js
+++ b/test/users.js
@@ -41,6 +41,11 @@ describe('users api', function() {
       { 'id': 2, 'name': 'Ciaran Davenport' }
    ]);
 
+  nock('https://rundef.testrail.com')
+    .get(testrail.uri + 'get_users/10')
+    .reply(200, [
+      { 'id': 1, 'name': 'Alexis Gonzalez' },
+    ]);
 
 
 
@@ -76,6 +81,15 @@ describe('users api', function() {
 
   it('Get all', function (done) {
     testrail.getUsers(function (err, response, body) {
+      expect(err).to.be.null;
+      expect(response).to.be.an.object;
+      expect(body).to.be.an.array;
+      done();
+    });
+  });
+
+  it('Get all by project', function (done) {
+    testrail.getUsers(10, function (err, response, body) {
       expect(err).to.be.null;
       expect(response).to.be.an.object;
       expect(body).to.be.an.array;


### PR DESCRIPTION
As stated in the https://www.gurock.com/testrail/docs/api/reference/users#getusers Documentation that from TestRail 6.4 and onwards you can pass a project_id parameter to this end point to get only users within the project.